### PR TITLE
Fixes for QuantumConnectors with VirtualChest

### DIFF
--- a/com/ne0nx3r0/quantum/listeners/QuantumConnectorsPlayerListener.java
+++ b/com/ne0nx3r0/quantum/listeners/QuantumConnectorsPlayerListener.java
@@ -119,7 +119,12 @@ public class QuantumConnectorsPlayerListener implements Listener{
     
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onInventoryOpen(InventoryOpenEvent e){
-        InventoryHolder ih = e.getInventory().getHolder();
+    	InventoryHolder ih;
+    	try{
+            ih = e.getInventory().getHolder();
+    	}catch(NullPointerException ex){
+    		return;
+    	}
         
         if(ih instanceof Chest){
             Location lChest = ((Chest) e.getInventory().getHolder()).getLocation();
@@ -152,7 +157,12 @@ public class QuantumConnectorsPlayerListener implements Listener{
     
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onInventoryClose(InventoryCloseEvent e){
-        InventoryHolder ih = e.getInventory().getHolder();
+    	InventoryHolder ih;
+    	try{
+            ih = e.getInventory().getHolder();
+    	}catch(NullPointerException ex){
+    		return;
+    	}
         
         if(ih instanceof Chest){
             Location lChest = ((Chest) ih).getLocation();


### PR DESCRIPTION
Remember me from 9 months ago when I knew nothing about coding and was really annoying? Well, at least the first one isn't true anymore.

I run QC with VirtualChest and it throws errors because the are InventoryOpen events with no holders. This fixes that problem by catching and ignoring the NPE. I'm already running it and it works great. Hopefully this gets pulled so I don't have to merge it over and over again.
